### PR TITLE
feat: added support for raw stats from RTCPeerConnection

### DIFF
--- a/src/js/rtc_session.js
+++ b/src/js/rtc_session.js
@@ -972,6 +972,16 @@ export default class RtcSession {
         }
 
     }
+    /**
+     * Get a promise containing raw object all RTCPeerConnection stats.
+     * @return Rejected promise if failed to get MediaRtpStats. The promise is never resolved with null value.
+     */
+    async getStatsRaw() {
+        if (this._pc && this._pc.signalingState === 'stable') {
+            return await this._pc.getStats(null);
+        }
+        return Promise.reject(new IllegalState());
+    }
 
     /**
      * Get a promise of MediaRtpStats object for remote audio (from Amazon Connect to client).


### PR DESCRIPTION
Issue #, if available:
Currently getStats() is translated and processed in a way that does not include native properties from RTCPeerConnection.getStats().

Description of changes:
This implementation allows for simple pulling directly from the native stats without additional translation and processing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.