### PR TITLE
fix: force plan-b format plan as default

### DIFF
--- a/src/js/rtc_session.js
+++ b/src/js/rtc_session.js
@@ -867,7 +867,8 @@ export default class RtcSession {
             iceServers: self._iceServers,
             iceTransportPolicy: 'relay',
             rtcpMuxPolicy: 'require',
-            bundlePolicy: 'balanced'
+            bundlePolicy: 'balanced',
+            sdpSemantics:'plan-b'
         }, {
             optional: [
                 {


### PR DESCRIPTION
*Issue #, if available:*
Chrome 72 will force default of sdpSemantics to 'unified-plan' and is breaking for connect. 

*Description of changes:*
Force default to standard 'plan-b' in RTCPeerConnection 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
