### PR TITLE
build: updated version of webrtc-adapter

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,14 +20,32 @@ module.exports = function(grunt) {
                     browserifyOptions: {
                         debug: true
                     },
-                    transform: [['babelify', { presets: ['env'] }]]
+                    transform: [
+                        [
+                            'babelify',
+                            {
+                                global: true,
+                                ignore: /\/node_modules\/(?!webrtc-adapter\/)/, // ignoring node_modules except webrtc-adapter
+                                presets: ['es2015']
+                            }
+                        ]
+                    ]
                 }
             },
             connectRtcGlobalObject: {
                 src: ['./src/js/connect-rtc.js'],
                 dest: './out/connect-rtc.js',
                 options: {
-                    transform: [['babelify', { presets: ['env'] }]]
+                    transform: [
+                        [
+                            'babelify',
+                            {
+                                global: true,
+                                ignore: /\/node_modules\/(?!webrtc-adapter\/)/, // ignoring node_modules except webrtc-adapter
+                                presets: ['es2015']
+                            }
+                        ]
+                    ]
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     }
   },
   "dependencies": {
-    "webrtc-adapter": "~2.0.5",
-    "uuid": "^3.0.1"
+    "uuid": "^3.0.1",
+    "webrtc-adapter": "^7.2.3"
   },
   "engines": {
     "npm": ">=3.10.0",
@@ -39,6 +39,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.3.2",
+    "babel-preset-es2015": "^6.24.1",
     "babelify": "^7.3.0",
     "chai": "^3.5.0",
     "chromedriver": "^2.28.0",


### PR DESCRIPTION
*Issue #, if available:*
Webrtc-adapter is a global shim and connect-rtc-js is very outdated. 

*Description of changes:*
Updated connect-rtc-js and grunt to allow for building with package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
